### PR TITLE
update kitchen.io url, lint fix README markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,23 +12,27 @@ A Test Kitchen Driver for [Linode](http://www.linode.com).
 
 ## <a name="requirements"></a> Requirements
 
-Requires [Test Kitchen](http://kitchen-ci.org) and a [Linode](http://www.linode.com) account.
-```
+Requires [Test Kitchen](https://kitchen.ci/) and a [Linode](http://www.linode.com) account.
+
+```sh
 gem install test-kitchen
 ```
 
 ## <a name="installation"></a> Installation and Setup
 
 The gem file is hosted at [RubyGems](https://rubygems.org/gems/kitchen-linode). To install the gem file, run:
-```
+
+```sh
 gem install kitchen-linode
 ```
+
 Or, install with bundler if you have a Gemfile
 Please read the [Driver usage][driver_usage] page for more details.
 
 ## <a name="config"></a> Configuration
 
 For many of these, you can specify an ID number, a full name, or a partial name that will try to match something in the list but may not match exactly what you want.
+
 ```
 LINODE_API_KEY      Linode API Key environment variable, default: nil
 :username           ssh user name, default: "root"
@@ -49,11 +53,14 @@ LINODE_API_KEY      Linode API Key environment variable, default: nil
 ## <a name="usage"></a> Usage
 
 First, set your Linode API key in an environment variable:
+
+```sh
+export LINODE_API_KEY='myrandomkey123123213h123bh12'
 ```
-$ export LINODE_API_KEY='myrandomkey123123213h123bh12'
-```
+
 Then, create a .kitchen.yml file:
-```
+
+```yaml
 ---
 driver:
   name: linode
@@ -72,12 +79,16 @@ platforms:
 suites:
   - name: default
 ```
+
 then you're ready to run `kitchen test` or `kitchen converge`
+
+```sh
+kitchen test
 ```
-$ kitchen test
-```
+
 If you want to create a second yaml config; one for using Vagrant locally but another to use the Linode driver when run on your CI server, create a config with a name like `.kitchen-ci.yml`:
-```
+
+```yaml
 ---
 driver:
   name: linode
@@ -96,13 +107,17 @@ platforms:
 suites:
   - name: default
 ```
+
 Then you can run the second config by changing the KITCHEN_YAML environment variable:
+
+```sh
+KITCHEN_YAML="./.kitchen-ci.yml" kitchen test
 ```
-$ KITCHEN_YAML="./.kitchen-ci.yml" kitchen test
-```
+
 If you want to change any of the default settings, you can do so in the 'platforms' area:
-```
-...<snip>...
+
+```yaml
+# ...<snip>...
 platforms:
   - name: debian_jessie
     driver:
@@ -110,7 +125,7 @@ platforms:
       data_center: Dallas
       kernel: 4.0.2-x86_64-linode56
       image: Debian 7
-...<snip>...
+# ...<snip>...
 ```
 
 ## <a name="development"></a> Development
@@ -137,8 +152,8 @@ Created and maintained by [Brett Taylor][author] (<btaylor@linode.com>)
 Apache 2.0 (see [LICENSE][license])
 
 
-[author]:           https://github.com/ssplatt
-[issues]:           https://github.com/ssplatt/kitchen-linode/issues
-[license]:          https://github.com/ssplatt/kitchen-linode/blob/master/LICENSE
-[repo]:             https://github.com/ssplatt/kitchen-linode
-[driver_usage]:     http://docs.kitchen-ci.org/drivers/usage
+[author]:           <https://github.com/ssplatt>
+[issues]:           <https://github.com/ssplatt/kitchen-linode/issues>
+[license]:          <https://github.com/ssplatt/kitchen-linode/blob/master/LICENSE>
+[repo]:             <https://github.com/ssplatt/kitchen-linode>
+[driver_usage]:     <https://kitchen.ci/docs/reference/configuration/>


### PR DESCRIPTION
The email address is also out of date.

It would be nice to get this listed on https://kitchen.ci/docs/drivers/, but perhaps that only makes sense after a Fog driver for Linode APIv4 exists and this project (or a new APIv4 version) adapts to that fog driver.